### PR TITLE
Permissions: new narrator and removal of inactive account from special

### DIFF
--- a/res/configs/permissions.yaml
+++ b/res/configs/permissions.yaml
@@ -16,10 +16,10 @@ narrator:
   - 8420046 # https://www.margonem.pl/profile/view,8420046 - Vaehl Apovas
   - 6657578 # https://www.margonem.pl/profile/view,6657578 - Rivian Devisson
   - 8450185 # https://www.margonem.pl/profile/view,8450185 - Fredrick Flumiene
+  - 9826541 # https://www.margonem.pl/profile/view,9826541 - Achalen
 special:
   - 5623545 # https://www.margonem.pl/profile/view,5623545 - Kris Aphalon
   - 70699 #  https://www.margonem.pl/profile/view,70699   - Ath`Lar Draa`Ilythiiri
-  - 30508 #  https://www.margonem.pl/profile/view,30508   - Leira Elamshin
   - 2328121 # https://www.margonem.pl/profile/view,2328121 - Shiraya
   - 345207 #  https://www.margonem.pl/profile/view,345207  - Minstrella
   - 883090 #  https://www.margonem.pl/profile/view,883090  - Noys Hollyhook-Rumore


### PR DESCRIPTION
Added Achalen to Narrators and removed Leira Elamshin (deleted Margonem account).